### PR TITLE
Fix/specified method is not supported

### DIFF
--- a/Internal/HttpClient.cs
+++ b/Internal/HttpClient.cs
@@ -303,7 +303,7 @@ namespace OBS.Internal
                 string temp;
                 try
                 {
-                    if (response.Content.Length > 0)
+                    if (response.Content.CanRead || response.Content.Length > 0)
                     {
                         CommonParser.ParseErrorResponse(response.Content, exception);
                     }

--- a/esdk_obs_.net_standard.csproj
+++ b/esdk_obs_.net_standard.csproj
@@ -38,7 +38,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="log4net" Version="2.0.8" />
 		<Folder Include="Properties\" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixes the issue reported here - https://github.com/huaweicloud/huaweicloud-sdk-dotnet-obs/issues/13 - where a failed CompleteMultipartUploadRequest would result in a `Specified method is not supported` error message, rather than the actual underlying message reported by OBS, due to attempting to read the length property of a non-seekable (but readable) stream.

Also, removes the redundant dependency on log4net (which is loaded dynamically, if found).

